### PR TITLE
Changed dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },


### PR DESCRIPTION
I don`t know if this change breaks anything but it solved a problem I had.
I use this module in a create-react-app. The problem was: inside the react code of one node I wanted to use a hook but this failed because (based on my understanding) the react compiling the component code was the react installed by create-react-app while the react trying to display it was the react installed with this module. This made it impossible to use hooks.

My solution (inspired from [this page](https://reactjs.org/warnings/invalid-hook-call-warning.html)): changed dependencies to peerDependencies in your module and installed the module from my forked repo.

Again, I don`t know if this breaks anything in other setups or, if there is a better solution.